### PR TITLE
linker: Make platform text relocations denial optional

### DIFF
--- a/linker/Android.mk
+++ b/linker/Android.mk
@@ -54,6 +54,14 @@ ifeq ($(TARGET_IS_64_BIT),true)
 LOCAL_CPPFLAGS += -DTARGET_IS_64_BIT
 endif
 
+ifeq ($(TARGET_NEEDS_PLATFORM_TEXT_RELOCATIONS),true)
+ifeq ($(user_variant),user)
+$(error Do not enable text relocations on user builds)
+else
+LOCAL_CPPFLAGS += -DTARGET_NEEDS_PLATFORM_TEXT_RELOCATIONS
+endif
+endif
+
 # We need to access Bionic private headers in the linker.
 LOCAL_CFLAGS += -I$(LOCAL_PATH)/../libc/
 

--- a/linker/linker.cpp
+++ b/linker/linker.cpp
@@ -3989,12 +3989,18 @@ bool soinfo::link_image(const soinfo_list_t& global_group, const soinfo_list_t& 
   if (has_text_relocations) {
     // Fail if app is targeting sdk version > 22
 #if !defined(__i386__) // ffmpeg says that they require text relocations on x86
+#if defined(TARGET_NEEDS_PLATFORM_TEXT_RELOCATIONS)
+    if (get_application_target_sdk_version() != __ANDROID_API__
+        && get_application_target_sdk_version() > 22) {
+#else
     if (get_application_target_sdk_version() > 22) {
+#endif
       PRINT("%s: has text relocations", get_realpath());
       DL_ERR("%s: has text relocations", get_realpath());
       return false;
     }
 #endif
+
     // Make segments writable to allow text relocations to work properly. We will later call
     // phdr_table_protect_segments() after all of them are applied.
     DL_WARN("%s has text relocations. This is wasting memory and prevents "


### PR DESCRIPTION
- Use the TARGET_NEEDS_PLATFORM_TEXT_RELOCATIONS := true
  configuration to allow a device to use legacy proprietary
  libraries like camera on non-user build variants
- Partial revert "Remove textrels support for platform libs"
  commit 8068786ae67835291521e52f39c695e40f3ad20d.

Change-Id: I994ab1a600a0b237b496ceebe2dd54febc28a6bd
